### PR TITLE
DEV-420 | Fix overlapping select clear button and chevron

### DIFF
--- a/packages/ui/src/select/Select.tsx
+++ b/packages/ui/src/select/Select.tsx
@@ -50,7 +50,15 @@ export const Select = forwardRef(function Select(
           {children}
         </HeadlessSelect>
         {!multiple && (
-          <span className='pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2'>
+          <span 
+            className={clsx(
+              'pointer-events-none absolute inset-y-0 flex items-center',
+              // Position chevron to the left of clear button when both are present
+              onClear && props?.value 
+                ? 'right-8 pr-0' // Clear button is present, position chevron to its left
+                : 'right-0 pr-2'  // No clear button, position at the end
+            )}
+          >
             <svg
               className='size-5 stroke-zinc-500 group-has-data-disabled:stroke-zinc-600 sm:size-4 dark:stroke-zinc-400 forced-colors:stroke-[CanvasText]'
               viewBox='0 0 16 16'


### PR DESCRIPTION
Adjust `Select` component chevron positioning to prevent overlap with the clear button.

The native dropdown chevron and the clear button from `InputContainer` were overlapping because both were positioned on the right side. This change dynamically repositions the chevron to the left of the clear button when `onClear` is enabled and a value is present, ensuring the clear button always remains at the end of the input.

---
Linear Issue: [DEV-420](https://linear.app/chunkcreations/issue/DEV-420/select-overlaping-clear-button-and-select-chevron)

<a href="https://cursor.com/background-agent?bcId=bc-14cb87f4-fa8c-4895-bebd-0368fc64aafc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-14cb87f4-fa8c-4895-bebd-0368fc64aafc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

